### PR TITLE
Api token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ pip3 install zegami-cli[sql]
 
 # Commands
 
+## Login
+The login command promtps for username and password which is then used to retrieve a long-lived API token which can be used for subsequent requests. The token is stored in a file in the currenet users data directory.
+Once retrieved all subsequest commands will use the stored token, unless it is specifically overridden wiht the `--token` option
+```
+zeg login
+```
+
 ## Get a collection
 Get the details of a collection.
 If the `collection id` is excluded then all collections will be listed.

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     packages=['zeg'],
     install_requires=[
+        'appdirs==1.4.0',
         'colorama==0.3.9',
         'PyYaml==3.12',
         'requests<3.0,>=2.15.0',

--- a/zeg/__main__.py
+++ b/zeg/__main__.py
@@ -110,7 +110,6 @@ def main():
             help='The id of the project.',
         )
         _add_standard_args(action_parser)
-        
 
     # login parser
     login_parser = subparsers.add_parser(

--- a/zeg/__main__.py
+++ b/zeg/__main__.py
@@ -127,7 +127,8 @@ def main():
         sys.exit(1)
 
     logger = log.Logger(args.verbose)
-    session = http.make_session(args.url, args.token)
+    token = auth.get_token(args)
+    session = http.make_session(args.url, token)
 
     if args.action == 'login':
         auth.login(

--- a/zeg/__main__.py
+++ b/zeg/__main__.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 import pkg_resources
 
 from . import (
+    auth,
     collections,
     datasets,
     http,
@@ -46,12 +47,26 @@ def main():
     )
 
     option_mapper = {
+        'delete': {
+            'help': 'Delete a resource',
+            'resources': {
+                'collections': collections.delete,
+                'dataset': datasets.delete,
+                'imageset': imagesets.delete,
+            }
+        },
         'get': {
             'help': 'Get a resource',
             'resources': {
                 'collections': collections.get,
                 'dataset': datasets.get,
                 'imageset': imagesets.get,
+            }
+        },
+        'publish': {
+            'help': 'Publish a resource',
+            'resources': {
+                'collection': collections.publish,
             }
         },
         'update': {
@@ -62,16 +77,9 @@ def main():
                 'imageset': imagesets.update,
             }
         },
-        'delete': {
-            'help': 'Delete a resource',
-            'resources': {
-                'collections': collections.delete,
-                'dataset': datasets.delete,
-                'imageset': imagesets.delete,
-            }
-        },
     }
 
+    # option mapper parser
     subparsers = parser.add_subparsers()
     for action in option_mapper:
         action_parser = subparsers.add_parser(
@@ -82,7 +90,7 @@ def main():
         action_parser.set_defaults(action=action)
         action_parser.add_argument(
             'resource',
-            choices=['collections', 'dataset', 'imageset'],
+            choices=option_mapper[action]['resources'].keys(),
             help='The name of the resource type.'
         )
         action_parser.add_argument(
@@ -101,24 +109,16 @@ def main():
             '--project',
             help='The id of the project.',
         )
-        action_parser.add_argument(
-            '-t',
-            '--token',
-            default=None,
-            help='Authentication token.',
-        )
-        action_parser.add_argument(
-            '-u',
-            '--url',
-            default='https://app.zegami.com',
-            help='Zegami server address.',
-        )
-        action_parser.add_argument(
-            '-v',
-            '--verbose',
-            action='store_true',
-            help='Enable verbose logging.',
-        )
+        _add_standard_args(action_parser)
+        
+
+    # login parser
+    login_parser = subparsers.add_parser(
+        'login',
+        help='Authenticate against the API and store a long lived token',
+    )
+    login_parser.set_defaults(action='login')
+    _add_standard_args(login_parser)
 
     args = parser.parse_args()
 
@@ -128,6 +128,14 @@ def main():
 
     logger = log.Logger(args.verbose)
     session = http.make_session(args.url, args.token)
+
+    if args.action == 'login':
+        auth.login(
+            logger,
+            session,
+            args,
+        )
+        return
 
     try:
         option_mapper[args.action]['resources'][args.resource](
@@ -139,6 +147,27 @@ def main():
         # unhandled exceptions
         logger.error('Unhandled exception: {}'.format(e))
         sys.exit(1)
+
+
+def _add_standard_args(parser):
+    parser.add_argument(
+        '-t',
+        '--token',
+        default=None,
+        help='Authentication token.',
+    )
+    parser.add_argument(
+        '-u',
+        '--url',
+        default='https://app.zegami.com',
+        help='Zegami server address.',
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='store_true',
+        help='Enable verbose logging.',
+    )
 
 
 if __name__ == '__main__':

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -41,10 +41,31 @@ def login(log, session, args):
     log('User token saved.')
 
 
+def get_token(args=None):
+    """
+    Get the users auth token.
+    If specified in the args then will use that over local config
+    """
+    token = args.token if 'token' in args else None
+    if token is None:
+        # look in user config
+        user_data = os.path.join(_get_user_dir(), '.auth')
+        if os.path.exists(user_data):
+            # see if something is inside
+            with open(user_data) as auth:
+                token = auth.read()
+
+    return token
+
+
+def _get_user_dir():
+    """Get the users data directory location."""
+    app_name = pkg_resources.require('zegami-cli')[0].project_name
+    return user_data_dir(app_name, 'zegami')
+
 def _init_conf_location():
     """Setup the config file location."""
-    app_name = pkg_resources.require('zegami-cli')[0].project_name
-    user_data = user_data_dir(app_name, 'zegami')
+    user_data = _get_user_dir()
     
     if not os.path.exists(user_data):
         os.makedirs(user_data)

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -2,17 +2,13 @@
 
 """Auth commands."""
 import os
+from getpass import getpass
 
 from appdirs import user_data_dir
-
-from colorama import Fore, Style
-
-from getpass import getpass
 
 import pkg_resources
 
 from . import (
-    config,
     http,
 )
 
@@ -37,13 +33,14 @@ def login(log, session, args):
 
     with open(user_data, 'w') as auth:
         auth.write(response['token'])
-    
+
     log('User token saved.')
 
 
 def get_token(args=None):
     """
     Get the users auth token.
+
     If specified in the args then will use that over local config
     """
     token = args.token if 'token' in args else None
@@ -63,10 +60,11 @@ def _get_user_dir():
     app_name = pkg_resources.require('zegami-cli')[0].project_name
     return user_data_dir(app_name, 'zegami')
 
+
 def _init_conf_location():
-    """Setup the config file location."""
+    """Initialise the config file location."""
     user_data = _get_user_dir()
-    
+
     if not os.path.exists(user_data):
         os.makedirs(user_data)
     return user_data

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -1,9 +1,13 @@
 # Copyright 2018 Zegami Ltd
 
 """Auth commands."""
-import sys
+import os
+
+from appdirs import user_data_dir
 
 from colorama import Fore, Style
+
+import pkg_resources
 
 from . import (
     config,
@@ -14,3 +18,18 @@ from . import (
 def login(log, session, args):
     """Authenticate and retrieve a long lived token."""
     log.warn('Login command coming soon.')
+    user_path = _init_conf_location()
+    user_data = os.path.join(user_path, '.auth')
+
+    with open(user_data, 'w') as auth:
+        auth.write('hello world')
+
+
+def _init_conf_location():
+    """Setup the config file location."""
+    app_name = pkg_resources.require('zegami-cli')[0].project_name
+    user_data = user_data_dir(app_name, 'zegami')
+    
+    if not os.path.exists(user_data):
+        os.makedirs(user_data)
+    return user_data

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -7,6 +7,8 @@ from appdirs import user_data_dir
 
 from colorama import Fore, Style
 
+from getpass import getpass
+
 import pkg_resources
 
 from . import (
@@ -17,12 +19,26 @@ from . import (
 
 def login(log, session, args):
     """Authenticate and retrieve a long lived token."""
-    log.warn('Login command coming soon.')
+    # set up user data location
     user_path = _init_conf_location()
     user_data = os.path.join(user_path, '.auth')
+    # get users auth details
+    username = input('Username: ')
+    password = getpass()
+    data = {
+        'username': username,
+        'password': password,
+        'noexpire': True
+    }
+    # time to authenticate
+    url = "{}/oauth/token/".format(args.url)
+    log.debug('POST: {}'.format(url))
+    response = http.post_json(session, url, data)
 
     with open(user_data, 'w') as auth:
-        auth.write('hello world')
+        auth.write(response['token'])
+    
+    log('User token saved.')
 
 
 def _init_conf_location():

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -1,0 +1,16 @@
+# Copyright 2018 Zegami Ltd
+
+"""Auth commands."""
+import sys
+
+from colorama import Fore, Style
+
+from . import (
+    config,
+    http,
+)
+
+
+def login(log, session, args):
+    """Authenticate and retrieve a long lived token."""
+    log.warn('Login command coming soon.')

--- a/zeg/collections.py
+++ b/zeg/collections.py
@@ -24,6 +24,28 @@ def get(log, session, args):
 
 def update(log, session, args):
     """Update a collection."""
+    log('colection id: {highlight}{id}{reset}',
+        highlight=Fore.GREEN,
+        id=args.id,
+        reset=Style.RESET_ALL)
+    log.warn('Update collection command coming soon.')
+
+
+def delete(log, session, args):
+    """Delete a collection."""
+    url = "{}collections/{}".format(
+        http.get_api_url(args.url, args.project),
+        args.id)
+    log.debug('DELETE: {}'.format(url))
+    http.delete(session, url)
+    log('collection {highlight}{id}{reset} deleted',
+        highlight=Fore.GREEN,
+        id=args.id,
+        reset=Style.RESET_ALL)
+
+
+def publish(log, session, args):
+    """Publish a collection."""
     coll_id = args.id if args.id is not None else ""
 
     # check for config
@@ -57,16 +79,3 @@ def update(log, session, args):
 
     response_json = http.post_json(session, url, publish_options)
     log.print_json(response_json, "collection", "update", shorten=False)
-
-
-def delete(log, session, args):
-    """Delete a collection."""
-    url = "{}collections/{}".format(
-        http.get_api_url(args.url, args.project),
-        args.id)
-    log.debug('DELETE: {}'.format(url))
-    http.delete(session, url)
-    log('collection {highlight}{id}{reset} deleted',
-        highlight=Fore.GREEN,
-        id=args.id,
-        reset=Style.RESET_ALL)


### PR DESCRIPTION
Moved around argument parsers to support `publish` action instead of using `update collection`.

Login action allows users to generate a long lived token which is stored in the users local data directory. The token is then used on subsequent requests if the `--token` argument is omitted.