### PR TITLE
[WIP] Try out two changes to improve image uploading

### DIFF
--- a/zeg/http.py
+++ b/zeg/http.py
@@ -7,6 +7,9 @@ import requests
 
 API_START_FORMAT = "{prefix}/api/v0/project/{project_id}/"
 
+# Max number of api requests to make at once.
+CONCURRENCY = 16
+
 
 class TokenEndpointAuth(requests.auth.AuthBase):
     """Request auth that adds bearer token for specific endpoint only."""


### PR DESCRIPTION
Limit concurrent api operations to 16 rather than based on cpu count.

Experiment with PUT for image details upload rather than using a POST
append operation. This is for comparision with the previous method
only, and does not yet correctly handle adding to existing imagesets.