### PR TITLE
Limit concurrent api requests to 16

### DIFF
--- a/zeg/http.py
+++ b/zeg/http.py
@@ -7,6 +7,9 @@ import requests
 
 API_START_FORMAT = "{prefix}/api/v0/project/{project_id}/"
 
+# Max number of api requests to make at once.
+CONCURRENCY = 16
+
 
 class TokenEndpointAuth(requests.auth.AuthBase):
     """Request auth that adds bearer token for specific endpoint only."""

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -84,7 +84,7 @@ def update(log, session, args):
         )
         sys.exit(1)
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(http.CONCURRENCY) as executor:
         paths = _resolve_paths(file_config['paths'])
         futures = [
             executor.submit(


### PR DESCRIPTION
Based on browser connection-per-hostname limits, clients should
probably have fewer open connections than the five-times-cpus that
the thread pool defaults to.