### PR TITLE
Add tox config for tests on many Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py34,py35,py36,flake8
+
+
+[testenv]
+commands = python -m unittest discover
+
+
+[testenv:flake8]
+deps = -rrequirements/test.txt
+skip_install = true
+commands =
+    flake8 zeg/ setup.py
+
+
+[flake8]
+ignore =
+    D1,
+    I1,
+application-import-names = zeg
+import-order-style = google

--- a/zeg/auth.py
+++ b/zeg/auth.py
@@ -1,11 +1,11 @@
 # Copyright 2018 Zegami Ltd
 
 """Auth commands."""
+
 import os
 from getpass import getpass
 
 from appdirs import user_data_dir
-
 import pkg_resources
 
 from . import (

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -1,15 +1,14 @@
 # Copyright 2018 Zegami Ltd
 
 """Collection commands."""
+
 import concurrent.futures
 import os
 import sys
 import uuid
 
 from colorama import Fore, Style
-
 from tqdm import tqdm
-
 
 from . import (
     config,

--- a/zeg/log.py
+++ b/zeg/log.py
@@ -5,7 +5,6 @@
 import copy
 
 from colorama import Fore, Style, init
-
 import yaml
 
 


### PR DESCRIPTION
Run tests on py34, py35, and py36, and lint with flake8.

Install run `tox` to use, though getting older Python binaries is an additional step.

Note, Python 3.4 passes as test coverage isn't all there yet, it should fail.