### PR TITLE
Long description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version='1.1.2',
     description='Command Line Interface for Zegami',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/zegami/zegami-cli',
     author='Zegami',
     author_email='help@zegami.com',


### PR DESCRIPTION
Descriptions that are not in reStructuredText format require the content
type to be specified as "text/markdown" instead. See
https://pypi.org/help/#description-content-type