### PR TITLE
Fix import on windows with Python 3.8/SQLAlchemy

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,10 +1,5 @@
-colorama==0.4.1
 flake8==3.7.9
 git+git://github.com/bz2/flake8-copyright@fea8229#egg=flake8-copyright
 flake8-docstrings==1.5.0
-flake8-import-order==0.16
-requests==2.22.0
-tqdm==4.20.0
-yamllint==1.10.0
-jsonschema==3.2.0
-azure==4.0.0
+flake8-import-order==0.18.1
+yamllint==1.20.0

--- a/setup.py
+++ b/setup.py
@@ -37,21 +37,18 @@ setup(
     packages=['zeg', 'zeg.tests'],
     install_requires=[
         'appdirs==1.4.3',
-        'azure-storage-blob==12.1.0',
-        'colorama==0.3.9',
-        'jsonschema==3.1.0',
-        'PyYaml==5.2',
+        'azure-storage-blob==12.3.0',
+        'colorama==0.4.3',
+        'jsonschema==3.2.0',
+        'PyYaml==5.3.1',
         'requests<3.0,>=2.15.0',
-        'tqdm==4.20.0',
+        'tqdm==4.43.0',
     ],
     extras_require={
         'sql': [
-            'pyodbc==4.0.24',
-            'SQLAlchemy==1.2.6',
+            'pyodbc==4.0.30',
+            'SQLAlchemy==1.3.15',
         ],
-        'test': [
-            'flake8==3.5.0',
-        ]
     },
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ envlist = py36,py37,py38,flake8
 
 [testenv]
 commands = python -m unittest discover
+extras = sql
 
 
 [testenv:flake8]
-deps = -r requirements/test.txt
+deps = -rrequirements/test.txt
 skip_install = true
 commands =
     flake8 zeg/ setup.py

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -175,7 +175,7 @@ def update_from_dict(log, session, configuration):
     elif ims_type == "azure_storage_container":
         if os.environ.get('AZURE_STORAGE_CONNECTION_STRING', None) is None:
             log.error(
-                "The AZURE_STORAGE_CONNECTION_STRING environment variable" +
+                "The AZURE_STORAGE_CONNECTION_STRING environment variable"
                 " must be set in order to create an azure storage collection"
             )
         configuration["url_template"] = azure_blobs.generate_signed_url(


### PR DESCRIPTION
Had an older version of SQLAlchemy pinned which attempts to use the
deprecated `time.clock()` on win32.

Update all dependencies and tox config to catch this issue with extra
packages when run on win32 at least.

Fix one lint error that snuck in.