### PR TITLE
Add support for azure-backed cloud in zegami-cli

### DIFF
--- a/zeg/http.py
+++ b/zeg/http.py
@@ -83,10 +83,11 @@ def make_session(endpoint, token):
 def handle_response(response):
     is_204 = response.status_code == 204
     is_200 = response.status_code == 200
+    is_201 = response.status_code == 201
 
     if response.status_code >= 300:
         raise ClientError(response)
-    elif (is_204 or is_200 and not response.content):
+    elif (is_204 or is_201 or is_200 and not response.content):
         return None
     try:
         json = response.json()
@@ -123,6 +124,8 @@ def delete(session, url):
 def put_file(session, url, filelike, mimetype):
     """Put binary content and decode json respose."""
     headers = {'Content-Type': mimetype}
+    if 'windows.net' in url:
+        headers['x-ms-blob-type'] = 'BlockBlob'
     with session.put(url, data=filelike, headers=headers) as response:
         return handle_response(response)
 

--- a/zeg/http.py
+++ b/zeg/http.py
@@ -124,6 +124,9 @@ def delete(session, url):
 def put_file(session, url, filelike, mimetype):
     """Put binary content and decode json respose."""
     headers = {'Content-Type': mimetype}
+    # Uploading blobs to azure requires us to specify the kind of blob
+    # Block blobs are typical object storage
+    # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#blobs
     if 'windows.net' in url:
         headers['x-ms-blob-type'] = 'BlockBlob'
     with session.put(url, data=filelike, headers=headers) as response:

--- a/zeg/tests/test_http.py
+++ b/zeg/tests/test_http.py
@@ -16,9 +16,18 @@ class Fake204(object):
     content = b''
 
 
+class Fake201(object):
+    status_code = 201
+    content = b''
+
+
 class ErrorHandlingTestCase(unittest.TestCase):
     def test_handle_response_204(self):
         out = http.handle_response(Fake204)
+        self.assertIs(out, None)
+
+    def test_handle_response_201(self):
+        out = http.handle_response(Fake201)
         self.assertIs(out, None)
 
     def test_handle_empty_response_200(self):


### PR DESCRIPTION
Azure returns `201 Created` status which were being treated as failures, and additionally provide the `x-ms-blob-type` header which is required when uploading files.

Also need to take a look at non-file puts and see if there's anything there as it looks like we're expecting some sort of json response which might not be there but so far I've only tested imageset upload (which now works fine).