### PR TITLE
Provide appropriate headers with PUTs to azure using http

### DIFF
--- a/zeg/http.py
+++ b/zeg/http.py
@@ -123,18 +123,27 @@ def delete(session, url):
 def put_file(session, url, filelike, mimetype):
     """Put binary content and decode json respose."""
     headers = {'Content-Type': mimetype}
+    headers.update(format_azure(url))
     with session.put(url, data=filelike, headers=headers) as response:
         return handle_response(response)
 
 
 def put_json(session, url, python_obj):
+    headers = format_azure(url)
     """Put json content and decode json response."""
-    with session.put(url, json=python_obj) as response:
+    with session.put(url, json=python_obj, headers=headers) as response:
         return handle_response(response)
 
 
 def put(session, url, data, content_type):
     """Put data and decode json response."""
     headers = {'Content-Type': content_type}
+    headers.update(format_azure(url))
     with session.put(url, data=data, headers=headers) as response:
         return handle_response(response)
+
+
+def format_azure(url):
+    if 'windows.net' in url:
+        return {'x-ms-blob-type': 'BlockBlob'}
+    return {}

--- a/zeg/http.py
+++ b/zeg/http.py
@@ -83,10 +83,11 @@ def make_session(endpoint, token):
 def handle_response(response):
     is_204 = response.status_code == 204
     is_200 = response.status_code == 200
+    is_201 = response.status_code == 201
 
     if response.status_code >= 300:
         raise ClientError(response)
-    elif (is_204 or is_200 and not response.content):
+    elif (is_204 or is_201 or is_200 and not response.content):
         return None
     try:
         json = response.json()
@@ -144,6 +145,9 @@ def put(session, url, data, content_type):
 
 
 def format_azure(url):
+    # Uploading blobs to azure requires us to specify the kind of blob
+    # Block blobs are typical object storage
+    # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#blobs
     if 'windows.net' in url:
         return {'x-ms-blob-type': 'BlockBlob'}
     return {}

--- a/zeg/http.py
+++ b/zeg/http.py
@@ -124,13 +124,13 @@ def delete(session, url):
 def put_file(session, url, filelike, mimetype):
     """Put binary content and decode json respose."""
     headers = {'Content-Type': mimetype}
-    headers.update(format_azure(url))
+    headers.update(get_platform_headers(url))
     with session.put(url, data=filelike, headers=headers) as response:
         return handle_response(response)
 
 
 def put_json(session, url, python_obj):
-    headers = format_azure(url)
+    headers = get_platform_headers(url)
     """Put json content and decode json response."""
     with session.put(url, json=python_obj, headers=headers) as response:
         return handle_response(response)
@@ -139,12 +139,12 @@ def put_json(session, url, python_obj):
 def put(session, url, data, content_type):
     """Put data and decode json response."""
     headers = {'Content-Type': content_type}
-    headers.update(format_azure(url))
+    headers.update(get_platform_headers(url))
     with session.put(url, data=data, headers=headers) as response:
         return handle_response(response)
 
 
-def format_azure(url):
+def get_platform_headers(url):
     # Uploading blobs to azure requires us to specify the kind of blob
     # Block blobs are typical object storage
     # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#blobs

--- a/zeg/tests/test_http.py
+++ b/zeg/tests/test_http.py
@@ -16,6 +16,11 @@ class Fake204(object):
     content = b''
 
 
+class Fake201(object):
+    status_code = 201
+    content = b''
+
+
 class ErrorHandlingTestCase(unittest.TestCase):
     def test_handle_response_204(self):
         out = http.handle_response(Fake204)
@@ -26,6 +31,10 @@ class ErrorHandlingTestCase(unittest.TestCase):
         resp._content = b''
         resp.status_code = 200
         out = http.handle_response(resp)
+        self.assertIs(out, None)
+
+    def test_handle_response_201(self):
+        out = http.handle_response(Fake201)
         self.assertIs(out, None)
 
     def test_provide_azure_headers(self):

--- a/zeg/tests/test_http.py
+++ b/zeg/tests/test_http.py
@@ -27,3 +27,10 @@ class ErrorHandlingTestCase(unittest.TestCase):
         resp.status_code = 200
         out = http.handle_response(resp)
         self.assertIs(out, None)
+
+    def test_provide_azure_headers(self):
+        url = 'https://fake.blob.core.windows.net/container/blob123'
+        headers = http.format_azure(url)
+        self.assertEqual(headers, {
+            'x-ms-blob-type': 'BlockBlob'
+        })

--- a/zeg/tests/test_http.py
+++ b/zeg/tests/test_http.py
@@ -39,7 +39,7 @@ class ErrorHandlingTestCase(unittest.TestCase):
 
     def test_provide_azure_headers(self):
         url = 'https://fake.blob.core.windows.net/container/blob123'
-        headers = http.format_azure(url)
+        headers = http.get_platform_headers(url)
         self.assertEqual(headers, {
             'x-ms-blob-type': 'BlockBlob'
         })


### PR DESCRIPTION
It's possible to get a signed URL back from azure projects but PUTs will fail because we don't properly handle them in http, this just adds the required header if the request is going to azure.