### PR TITLE
Version bump to 1.1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='zegami-cli',
-    version='1.1.6',
+    version='1.1.7',
     description='Command Line Interface for Zegami',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Release drafted, will update requirements on e2e tests to include the new version.