### PR TITLE
Batch image upload operations in the CLI

### DIFF
--- a/zeg/collections.py
+++ b/zeg/collections.py
@@ -2,6 +2,7 @@
 
 """Collection commands."""
 import sys
+from datetime import datetime
 
 from colorama import Fore, Style
 
@@ -26,6 +27,7 @@ def get(log, session, args):
 
 def create(log, session, args):
     """Get a collection."""
+    time_start = datetime.now()
     url = "{}collections/".format(
         http.get_api_url(args.url, args.project),)
     log.debug('POST: {}'.format(url))
@@ -54,6 +56,8 @@ def create(log, session, args):
     imageset_config["dataset_id"] = coll["dataset_id"]
     imageset_config["collection_id"] = coll["id"]
     imagesets.update_from_dict(log, session, imageset_config)
+    delta_time = datetime.now() - time_start
+    log.debug("Collection uploaded in {}".format(delta_time))
 
 
 def update(log, session, args):

--- a/zeg/http.py
+++ b/zeg/http.py
@@ -65,7 +65,7 @@ def make_session(endpoint, token):
 
     # Retry post requests as well as the usual methods.
     retry_methods = urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST.union(
-        ('POST'))
+        ('POST', 'PUT'))
     retry = urllib3.util.retry.Retry(
         total=10,
         backoff_factor=0.5,

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -123,7 +123,7 @@ def _upload_image_chunked(paths, session, create_url, complete_url, log, workloa
     try:
         url = complete_url + "?start={}".format(workload_info["start"])
         log.debug("POSTING TO: {}".format(url))
-        http.post_json(session, url, results)
+        http.post_json(session, url, {'images': results})
     except Exception as ex:
         log.error("Failed to complete workload: {}".format(ex))
 


### PR DESCRIPTION
Took a while to understand `futures` and understand where the bottlenecks where, but this a bit of an excerpt that should be much faster assuming the bulk endpoint is available in cloud. That's in a separate pr on `zegami-cloud`