### PR TITLE
Write from the end of an imageset rather than from 0 every time

### DIFF
--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -51,14 +51,14 @@ def _get_chunk_upload_futures(
     workloads = []
     temp = []
 
-    i = offset
-    while i < total_work + offset:
+    i = 0
+    while i < total_work:
         path = paths[i]
         temp.append(path)
         i += 1
         if len(temp) == workload_size or i == total_work:
             workload_info = {
-                "start": i - len(temp),
+                "start": i - len(temp) + offset,
                 "count": len(temp),
             }
             workloads.append(executor.submit(

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -37,7 +37,8 @@ def get(log, session, args):
 
 
 def _get_chunk_upload_futures(
-    executor, paths, session, create_url, complete_url, log, workload_size, offset
+    executor, paths, session, create_url,
+    complete_url, log, workload_size, offset
 ):
     """Return executable tasks with image uploads in batches.
 
@@ -147,7 +148,9 @@ def _update_file_imageset(log, session, configuration):
 
     # first extend the imageset by the number of items we have to upload
     paths = _resolve_paths(file_config['paths'])
-    extend_response = http.post_json(session, extend_url, {'delta': len(paths)})
+    extend_response = http.post_json(
+        session, extend_url, {'delta': len(paths)}
+    )
     add_offset = extend_response['new_size'] - len(paths)
 
     workload_size = optimal_workload_size(len(paths))


### PR DESCRIPTION
This fixes a rather critical issue where updating an existing imageset could result in overwriting from 0, had a bit of tunnelvision when first implementing this that the thought of updating an imageset after the fact escaped my mind. This effectively avoids the problem by always starting from the end of an imageset.

Only potential problem, if the upload process is cancelled/stopped prematurely, there will be lots of nulls in the imageset.