### PR TITLE
Ignore some file types/extensions even when forcing mime type

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
 max_line_length = 120
-ignore = W504,W503

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max_line_length = 120
+ignore = W504,W503

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,6 @@ commands =
 ignore =
     D1,
     I1,
+    W5,
 application-import-names = zeg
 import-order-style = google

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -27,6 +27,15 @@ MIMES = {
     ".dcm": "application/dicom",
 }
 
+BLACKLIST = tuple(
+    ".yaml",
+    "thumbs.db",
+    ".ds_store",
+    ".dll",
+    ".sys",
+    ".txt",
+)
+
 
 def get(log, session, args):
     """Get an image set."""
@@ -170,7 +179,7 @@ def _update_file_imageset(log, session, configuration):
 
     # first extend the imageset by the number of items we have to upload
     paths = _resolve_paths(
-        file_config['paths'], recursive, mime_type is not None
+        file_config['paths'], recursive, mime_type is not None, log
     )
 
     if len(paths) == 0:
@@ -378,9 +387,10 @@ def delete(log, session, args):
     log.warn('delete imageset command coming soon.')
 
 
-def _resolve_paths(paths, should_recursive, ignore_mime):
+def _resolve_paths(paths, should_recursive, ignore_mime, log):
     """Resolve all paths to a list of files."""
     allowed_ext = tuple(MIMES.keys())
+    blacklist_ext = BLACKLIST
 
     resolved = []
     for path in paths:
@@ -388,13 +398,14 @@ def _resolve_paths(paths, should_recursive, ignore_mime):
         if os.path.isdir(path):
             if should_recursive:
                 resolved.extend(
-                    _scan_directory_tree(path, allowed_ext, ignore_mime)
+                    _scan_directory_tree(path, allowed_ext, blacklist_ext, ignore_mime, log)
                 )
             else:
                 resolved.extend(
                     entry.path for entry in os.scandir(path)
                     if entry.is_file() and (
-                        entry.name.lower().endswith(allowed_ext) or ignore_mime
+                        entry.name.lower().endswith(allowed_ext) or
+                        (ignore_mime and not entry.name.lower().endswith(blacklist_ext))
                     )
                 )
         elif os.path.isfile(path) and whitelisted:
@@ -402,16 +413,20 @@ def _resolve_paths(paths, should_recursive, ignore_mime):
     return resolved
 
 
-def _scan_directory_tree(path, allowed_ext, ignore_mime):
+def _scan_directory_tree(path, allowed_ext, blacklist_ext, ignore_mime, log):
     files = []
     for entry in os.scandir(path):
         whitelisted = entry.name.lower().endswith(allowed_ext)
-        if ignore_mime:
+        if ignore_mime and not whitelisted:
             whitelisted = True
+        # Some files should not be uploaded even if we are forcing mime type.
+        if entry.name.lower().endswith(blacklist_ext):
+            whitelisted = False
+            log.debug("Ignoring file due to disallowed extension: {}".format(entry.name))
         if entry.is_file() and whitelisted:
             files.append(entry.path)
         if entry.is_dir():
-            files.extend(_scan_directory_tree(entry.path, allowed_ext, ignore_mime))
+            files.extend(_scan_directory_tree(entry.path, allowed_ext, blacklist_ext, ignore_mime, log))
     return files
 
 

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -405,7 +405,9 @@ def _resolve_paths(paths, should_recursive, ignore_mime):
 def _scan_directory_tree(path, allowed_ext, ignore_mime):
     files = []
     for entry in os.scandir(path):
-        whitelisted = (entry.name.lower().endswith(allowed_ext) or ignore_mime)
+        whitelisted = entry.name.lower().endswith(allowed_ext)
+        if ignore_mime:
+            whitelisted = True
         if entry.is_file() and whitelisted:
             files.append(entry.path)
         if entry.is_dir():

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -27,7 +27,7 @@ MIMES = {
     ".dcm": "application/dicom",
 }
 
-BLACKLIST = tuple(
+BLACKLIST = (
     ".yaml",
     "thumbs.db",
     ".ds_store",


### PR DESCRIPTION
When recursively scanning directories but forcing mime type with image only collections, sometimes junk such as `thumbs.db` (windows) and `.DS_Store` (mac) get uploaded which causes erroneous entries in the collection. Similarly the `.yaml` file is obviously not an image, so along with a few other obvious entries, check against a blacklist when ignoring mime type.