### PR TITLE
Warn when uploading files larger than 256MB

### DIFF
--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -426,7 +426,7 @@ def _resolve_paths(paths, should_recursive, ignore_mime, log):
 def format_bytes(size):
     power = 1024
     n = 0
-    power_labels = {0 : '', 1: 'K', 2: 'B', 3: 'G', 4: 'T'}
+    power_labels = {0: '', 1: 'K', 2: 'B', 3: 'G', 4: 'T'}
     while size > power:
         size /= power
         n += 1

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -410,7 +410,27 @@ def _resolve_paths(paths, should_recursive, ignore_mime, log):
                 )
         elif os.path.isfile(path) and whitelisted:
             resolved.append(path)
+
+    total_size = 0
+    warned = False
+    for path in resolved:
+        size = os.path.getsize(path)
+        total_size += size
+        if size > 268435456 and not warned:
+            log.warn("One or more files exceeds 256MB, collection processing may be unreliable.")
+            warned = True
+    log.debug("Total upload size: {}".format(format_bytes(total_size)))
     return resolved
+
+
+def format_bytes(size):
+    power = 1024
+    n = 0
+    power_labels = {0 : '', 1: 'K', 2: 'B', 3: 'G', 4: 'T'}
+    while size > power:
+        size /= power
+        n += 1
+    return "{}{}B".format(round(size, 2), power_labels[n])
 
 
 def _scan_directory_tree(path, allowed_ext, blacklist_ext, ignore_mime, log):

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -36,6 +36,10 @@ BLACKLIST = (
     ".txt",
 )
 
+# When a file is larger than 256MB throw up a warning.
+# Collection processing may be unreliable when handling files larger than this.
+UPLOAD_WARNING_LIMIT = 268435456
+
 
 def get(log, session, args):
     """Get an image set."""
@@ -416,7 +420,7 @@ def _resolve_paths(paths, should_recursive, ignore_mime, log):
     for path in resolved:
         size = os.path.getsize(path)
         total_size += size
-        if size > 268435456 and not warned:
+        if size > UPLOAD_WARNING_LIMIT and not warned:
             log.warn("One or more files exceeds 256MB, collection processing may be unreliable.")
             warned = True
     log.debug("Total upload size: {}".format(format_bytes(total_size)))


### PR DESCRIPTION
Attempting to upload a file larger than 256MB will result in a yellow warning.

Additionally the total upload file-size will be output when the verbose flag is provided.

Example:

```
One or more files exceeds 256MB, collection processing may be unreliable.
Total upload size: 2.42GB
  0%|                                                             | 0.00/4.00 [00:00<?, ?image/s]
```