### PR TITLE
Extend imageset file blacklist

### DIFF
--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -34,6 +34,10 @@ BLACKLIST = (
     ".dll",
     ".sys",
     ".txt",
+    ".tsv",
+    ".csv",
+    ".yaml",
+    ".json"
 )
 
 # When a file is larger than 256MB throw up a warning.


### PR DESCRIPTION
Extend imageset file blacklist to include commonly used data file format extensions

https://zegami.atlassian.net/browse/ZGM-6327