### PR TITLE
Fix a typo when reporting filesize for upload

### DIFF
--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -29,11 +29,13 @@ MIMES = {
 
 BLACKLIST = (
     ".yaml",
+    ".yml",
     "thumbs.db",
     ".ds_store",
     ".dll",
     ".sys",
     ".txt",
+    ".ini",
     ".tsv",
     ".csv",
     ".json"

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -36,7 +36,6 @@ BLACKLIST = (
     ".txt",
     ".tsv",
     ".csv",
-    ".yaml",
     ".json"
 )
 
@@ -436,7 +435,7 @@ def _resolve_paths(paths, should_recursive, ignore_mime, log):
 def format_bytes(size):
     power = 1024
     n = 0
-    power_labels = {0: '', 1: 'K', 2: 'B', 3: 'G', 4: 'T'}
+    power_labels = {0: '', 1: 'K', 2: 'M', 3: 'G', 4: 'T'}
     while size > power:
         size /= power
         n += 1


### PR DESCRIPTION
This was going to be a much bigger PR with some overhauls on the upload progress and how we use `tqdm` to use current/total upload bytes for progress rather than iteration on the `as_completed` future iterator, but that's a bigger bite than worth chewing right now given the measure of testing & fiddling required to get it right so I've raised a task to improve this, I did try but it wasn't super straightforward to implement consistently.

Also removed duplicate entry on the blacklist for `.yaml`.