### PR TITLE
Add command for listing projects available to current user

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='zegami-cli',
-    version='1.4.1',
+    version='1.4.2',
     description='Command Line Interface for Zegami',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/zeg/__main__.py
+++ b/zeg/__main__.py
@@ -16,6 +16,7 @@ from . import (
     datasets,
     http,
     imagesets,
+    projects,
     log,
 )
 
@@ -60,6 +61,12 @@ def main():
             'help': 'Create a resource',
             'resources': {
                 'collections': collections.create,
+            }
+        },
+        'list': {
+            'help': 'Lists entries of a resource',
+            'resources': {
+                'projects': projects.enumerate,
             }
         },
         'get': {

--- a/zeg/projects.py
+++ b/zeg/projects.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Zegami Ltd
+
+"""Collection commands."""
+import sys
+
+from . import (
+    config,
+    datasets,
+    imagesets,
+    http,
+)
+
+
+def enumerate(log, session, args):
+    """Get a list of available workspaces (projects)."""
+    url = "{}/oauth/userinfo/".format(
+        args.url)
+    log.debug('GET: {}'.format(url))
+    response_json = http.get(session, url)
+    abv_output = {}
+    for p in response_json["projects"]:
+        abv_output[p['id']] = p['name']
+    log.print_json(abv_output, "projects", "list", shorten=False)

--- a/zeg/projects.py
+++ b/zeg/projects.py
@@ -1,12 +1,7 @@
 # Copyright 2018 Zegami Ltd
 
-"""Collection commands."""
-import sys
-
+"""Project commands."""
 from . import (
-    config,
-    datasets,
-    imagesets,
     http,
 )
 


### PR DESCRIPTION
Use like `zeg list projects`, example:

```
matthewhall@Matthews-Mac-mini zegami-cli % zeg list projects -u https://staging.zegami.com --v
GET: https://staging.zegami.com/oauth/userinfo/
=========================================
list projects with result:
-----------------------------------------
3q7if47h: matt+azure@zegami.com's workspace
idUpFsFf: ahaith Azure

=========================================
```