### PR TITLE
Casting the name to string before validation

### DIFF
--- a/zeg/collections.py
+++ b/zeg/collections.py
@@ -42,7 +42,7 @@ def create(log, session, args):
 
     # use name from config
     coll = {
-        "name": str(configuration["name"]),
+        "name": configuration["name"],
     }
     # use description and enable_clustering from config
     for key in ["description", "enable_clustering"]:

--- a/zeg/config.py
+++ b/zeg/config.py
@@ -23,6 +23,7 @@ def parse_args(args, log):
 def parse_config(path, log):
     """Parse yaml collection configuration."""
     configuration = load_config(path)
+    configuration['name'] = str(configuration['name'])
     validate_config(configuration, log)
     return configuration
 


### PR DESCRIPTION
This happens in the parse_config function as otherwise
the configuration cannot be validated in the validate_config function

Removed the casting from collections.py as it's not needed anymore

https://zegami.atlassian.net/browse/ZGM-6706