### PR TITLE
This is a fix for PR #93

### DIFF
--- a/zeg/config.py
+++ b/zeg/config.py
@@ -23,7 +23,8 @@ def parse_args(args, log):
 def parse_config(path, log):
     """Parse yaml collection configuration."""
     configuration = load_config(path)
-    configuration['name'] = str(configuration['name'])
+    if 'name' in configuration:
+        configuration['name'] = str(configuration['name'])
     validate_config(configuration, log)
     return configuration
 


### PR DESCRIPTION
The previous PR broke any actions other than creating collections

As only collection creation requires a name in the config