### PR TITLE
Compare with source_name rather than source_id

### DIFF
--- a/zeg/collections.py
+++ b/zeg/collections.py
@@ -90,9 +90,9 @@ def create(log, session, args):
             imageset_config["project"] = configuration["project"]
             imageset_config["dataset_id"] = coll["dataset_id"]
             imageset_config["collection_id"] = coll["id"]
-            for source in coll["image_sources"]:
-                if source['source_id'] == source_name:
-                    imageset_config["id"] = source["imageset_id"]
+            for coll_source in coll["image_sources"]:
+                if coll_source['name'] == source_name:
+                    imageset_config["id"] = coll_source["imageset_id"]
             imagesets.update_from_dict(log, session, imageset_config)
     else:
         imageset_config = dict(

--- a/zeg/imagesets.py
+++ b/zeg/imagesets.py
@@ -258,7 +258,7 @@ def _update_join_dataset(
     if 'source_name' in configuration:
         source_name = configuration['source_name']
         for source in collection["image_sources"]:
-            if source['source_id'] == source_name:
+            if source['name'] == source_name:
                 ims_ds_join_id = source["imageset_dataset_join_id"]
     else:
         ims_ds_join_id = collection["imageset_dataset_join_id"]


### PR DESCRIPTION
Relates to the change [PR](https://github.com/zegami/zegami-cloud/pull/978) because we made `source_id` different with `source_name`