### PR TITLE
Support creating wsi collection

### DIFF
--- a/zeg/collections.py
+++ b/zeg/collections.py
@@ -45,7 +45,7 @@ def create(log, session, args):
         "name": configuration["name"],
     }
     # use description and enable_clustering from config
-    for key in ["description", "enable_clustering", "enable_image_info"]:
+    for key in ["description", "enable_clustering", "enable_image_info", "use_wsi"]:
         if key in configuration:
             coll[key] = configuration[key]
 

--- a/zeg/schemata/spec.yaml
+++ b/zeg/schemata/spec.yaml
@@ -79,6 +79,9 @@ definitions:
       enable_clustering:
         type: boolean
         description: whether to enable clustering for the collection
+      use_wsi:
+        type: boolean
+        description: whether the images are whole slide images
     required:
     - name
   file_dataset:


### PR DESCRIPTION
Add `use_wsi` flag
Have tested that the wsi collection is successfully created and published on top of [PR](https://github.com/zegami/zegami-cloud/pull/1013)

https://zegami.atlassian.net/browse/ZGM-7078